### PR TITLE
Expose log files from container

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,6 +19,7 @@ ingress_port: 8000
 ingress_stream: true
 map:
   - type: ssl
+  - type: addon_config:rw
 stage: experimental
 options:
   adminuser: "admin"

--- a/icecast.xml
+++ b/icecast.xml
@@ -219,9 +219,9 @@
     </paths>
 
     <logging>
-        <accesslog>access.log</accesslog>
-        <errorlog>error.log</errorlog>
-        <playlistlog>playlist.log</playlistlog>
+        <accesslog>/config/access.log</accesslog>
+        <errorlog>/config/error.log</errorlog>
+        <playlistlog>/config/playlist.log</playlistlog>
         <loglevel>3</loglevel> <!-- 4 Debug, 3 Info, 2 Warn, 1 Error -->
         <logsize>10000</logsize> <!-- Max size of a logfile -->
         <!-- If logarchive is enabled (1), then when logsize is reached


### PR DESCRIPTION
This mounts a /config directory inside the container. I've turned on rw so that we can write log files to this directory. The directory is mounted from /addon_configs/<repo_slug>/ so we can check the files from inside home assistant at that path.

The icecast config has been updated to write it's log files to this /config directory.

See https://developers.home-assistant.io/docs/add-ons/configuration/#add-on-advanced-options